### PR TITLE
use German utf-quotes

### DIFF
--- a/ftplugin/latex-suite/packages/german
+++ b/ftplugin/latex-suite/packages/german
@@ -6,7 +6,12 @@ let german_package_file = 1
 let g:TeX_package_german = ''
 let g:TeX_package_option_german = ''
 " For now just define the smart quotes.
-let b:Tex_SmartQuoteOpen = '"`'
-let b:Tex_SmartQuoteClose = "\"'"
+if g:Tex_inputenc_options =~ '\<utf8\>'
+  let b:Tex_SmartQuoteOpen = '„'
+  let b:Tex_SmartQuoteClose = '“'
+else
+  let b:Tex_SmartQuoteOpen = '"`'
+  let b:Tex_SmartQuoteClose = "\"'"
+endif
 
 " vim:ft=vim:ff=unix:

--- a/ftplugin/latex-suite/packages/ngerman
+++ b/ftplugin/latex-suite/packages/ngerman
@@ -6,7 +6,12 @@ let ngerman_package_file = 1
 let g:TeX_package_ngerman = ''
 let g:TeX_package_option_ngerman = ''
 " For now just define the smart quotes.
-let b:Tex_SmartQuoteOpen = '"`'
-let b:Tex_SmartQuoteClose = "\"'"
+if g:Tex_inputenc_options =~ '\<utf8\>'
+  let b:Tex_SmartQuoteOpen = '„'
+  let b:Tex_SmartQuoteClose = '“'
+else
+  let b:Tex_SmartQuoteOpen = '"`'
+  let b:Tex_SmartQuoteClose = "\"'"
+endif
 
 " vim:ft=vim:ff=unix:


### PR DESCRIPTION
When the packages ngerman, german or babel with a corresponding option are detected, smart quotes are set to regional variants, expressed as escapes. When inputenc additionally indicates that the file is encoded in utf, native symbols can be used instead, which may make the LaTeX code easier to read. This pull request performs the necessary changes to do so for German.