### PR TITLE
Configurable bibliography file generation detection

### DIFF
--- a/ftplugin/latex-suite/compiler.vim
+++ b/ftplugin/latex-suite/compiler.vim
@@ -584,9 +584,10 @@ function! Tex_CompileMultipleTimes()
 			let needToRerun = 1
 		endif
 
-		" The first time we see if we need to run bibtex and if the .bbl file
+		" The first time we see if we need to generate the bibliography and if the .bbl file
 		" changes, we will rerun latex.
-		if runCount == 0 && Tex_IsPresentInFile('\\bibdata', mainFileName_root.'.aux')
+		" We use '\\bibdata' as a check for BibTeX and '\\abx' as a check for biber.
+		if runCount == 0 && Tex_IsPresentInFile('\\bibdata|\\abx', mainFileName_root.'.aux')
 			let bibFileName = mainFileName_root.'.bbl'
 
 			let biblinesBefore = Tex_CatFile(bibFileName)


### PR DESCRIPTION
This PR fixes #8 by making the bibliography file ending configurable (e.g. allowing changing '.bbl' which is used by BibTeX to '.bcf' which is used by biber), and the string that is to detect when to run the specified flavor/engine.

The commit is partially inspired by answers found in:
http://tex.stackexchange.com/questions/83715/biber-backend-and-vim-latex.

Any comments are welcome.