### PR TITLE
Fixes filename tracking in errorformat

### DIFF
--- a/compiler/tex.vim
+++ b/compiler/tex.vim
@@ -227,21 +227,27 @@ function! <SID>SetLatexEfm()
 	exec 'setlocal efm+=%'.pm.'G%.%#\ (C)\ %.%#'
 	exec 'setlocal efm+=%'.pm.'G(see\ the\ transcript%.%#)'
 	exec 'setlocal efm+=%'.pm.'G\\s%#'
-	exec 'setlocal efm+=%'.pm.'O(%*[^()])%r'
+
+	" detect what file the messages are referring to
 	exec 'setlocal efm+=%'.pm.'P(%f%r'
 	exec 'setlocal efm+=%'.pm.'P\ %\\=(%f%r'
 	exec 'setlocal efm+=%'.pm.'P%*[^()](%f%r'
-	exec 'setlocal efm+=%'.pm.'P(%f%*[^()]'
 	exec 'setlocal efm+=%'.pm.'P[%\\d%[^()]%#(%f%r'
 	if g:Tex_IgnoreUnmatched && !g:Tex_ShowallLines
-		setlocal efm+=%-P%*[^()]
+		setlocal efm+=%-P%*[^()]%r
 	endif
 	exec 'setlocal efm+=%'.pm.'Q)%r'
 	exec 'setlocal efm+=%'.pm.'Q%*[^()])%r'
 	exec 'setlocal efm+=%'.pm.'Q[%\\d%*[^()])%r'
 	if g:Tex_IgnoreUnmatched && !g:Tex_ShowallLines
-		setlocal efm+=%-Q%*[^()]
+		setlocal efm+=%-Q%*[^()]%r
 	endif
+	exec 'setlocal efm+=%'.pm.'O(%f)%r'
+	exec 'setlocal efm+=%'.pm.'P(%f'
+	exec 'setlocal efm+=%'.pm.'P(%f%*[^()]'
+	exec 'setlocal efm+=%'.pm.'Q)'
+	exec 'setlocal efm+=%'.pm.'Q%*[^()])'
+
 	if g:Tex_IgnoreUnmatched && !g:Tex_ShowallLines
 		setlocal efm+=%-G%.%#
 	endif


### PR DESCRIPTION
Fixes an incorrect `'errorformat'` set by vim-latex to the [correct ones in the latest Vim documentation](https://github.com/vim/vim/blob/04b9beaaffb40072a8ce12b8b69119924c3fd93d/runtime/doc/quickfix.txt#L1437-L1444).
