### PR TITLE
Adds an errorformat for LaTeX Font Warnings

### DIFF
--- a/compiler/tex.vim
+++ b/compiler/tex.vim
@@ -211,6 +211,7 @@ function! <SID>SetLatexEfm()
 	setlocal efm+=%+WLaTeX\ %.%#Warning:\ %.%#line\ %l%.%#
 	setlocal efm+=%+W%.%#\ at\ lines\ %l--%*\\d
 	setlocal efm+=%+WLaTeX\ %.%#Warning:\ %m
+	setlocal efm+=%+WLaTeX\ Font\ Warning:\ %m,%Z(Font)\ %#%m\ on\ input\ line\ %l.,%C(Font)\ %#%m
 
 	exec 'setlocal efm+=%'.pm.'Cl.%l\ %m'
 	exec 'setlocal efm+=%'.pm.'Cl.%l\ '


### PR DESCRIPTION
That recognizes warnings such as the following:

```
LaTeX Font Warning: Font shape `OT1/cmr/bx/sc' undefined
(Font)              using `OT1/cmr/bx/n' instead on input line 1321.
```

Or:

```
LaTeX Font Warning: Font shape `OT1/cmss/m/it' in size <9> not available
(Font)              Font shape `OT1/cmss/m/sl' tried instead on input line 328.
```
