### PR TITLE
Bug fix: When pressing <F5> in the preamble, it will insert environme…

### DIFF
--- a/ftplugin/latex-suite/envmacros.vim
+++ b/ftplugin/latex-suite/envmacros.vim
@@ -654,7 +654,6 @@ if g:Tex_PromptedEnvironments != ''
 			" the file, then a part of the file is the preamble.
 
 			" search for where the document begins.
-			call Tex_SetPos(pos)
 			let begin_line = search('\\begin{document}')
 			" if the document begins after where we are presently, then we are
 			" in the preamble.

--- a/ftplugin/latex-suite/envmacros.vim
+++ b/ftplugin/latex-suite/envmacros.vim
@@ -654,6 +654,7 @@ if g:Tex_PromptedEnvironments != ''
 			" the file, then a part of the file is the preamble.
 
 			" search for where the document begins.
+			call Tex_SetPos(pos)
 			let begin_line = search('\\begin{document}')
 			" if the document begins after where we are presently, then we are
 			" in the preamble.

--- a/ftplugin/latex-suite/packages.vim
+++ b/ftplugin/latex-suite/packages.vim
@@ -294,7 +294,9 @@ function! Tex_pack_one(...)
 					let retVal = retVal.'\usepackage{'.packname.'}'."\<CR>"
 				endif
 			else
-				let retVal = retVal.'\usepackage{'.packname.'}'."\<CR>"
+				" let retVal = retVal.'\usepackage{'.packname.'}'."\<CR>"
+				" I always want options
+				let retVal = retVal.'\usepackage[<++>]{'.packname.'}<++>'
 			endif
 			let omega = omega + 1
 		endwhile


### PR DESCRIPTION
# Bug Description
When I try to insert a package in the preampble, I type the package name and press <F5>.
However, an environment (\begin{}...\end{}) is inserted.
# VIM Version
VIM - Vi IMproved 7.4 (2013 Aug 10, compiled Sep  1 2015 15:31:48)
Included patches: 1-854
Compiled by Arch Linux
