### PR TITLE
more utf-quotes, now for English

### DIFF
--- a/ftplugin/latex-suite/packages/babel
+++ b/ftplugin/latex-suite/packages/babel
@@ -91,6 +91,11 @@ function! <SID>SetQuotes()
             exec 'so '.s:path.'/german'
         elseif g:Tex_babel_options =~ '\<ngerman\>'
             exec 'so '.s:path.'/ngerman'
+        elseif g:Tex_babel_options =~ '\<english\|USenglish\|american\|UKenglish\|british\|canadian\>'
+          if g:Tex_inputenc_options =~ '\<utf8\>'
+            let b:Tex_SmartQuoteOpen = '“'
+            let b:Tex_SmartQuoteClose = '”'
+          endif
         endif
     endif
 endfunction " }}}

--- a/ftplugin/latex-suite/packages/babel
+++ b/ftplugin/latex-suite/packages/babel
@@ -89,7 +89,7 @@ function! <SID>SetQuotes()
     if g:Tex_package_detected =~ '\<babel\>'
         if g:Tex_babel_options =~ '\<german\>'
             exec 'so '.s:path.'/german'
-		elseif g:Tex_babel_options =~ '\<ngerman\>'
+        elseif g:Tex_babel_options =~ '\<ngerman\>'
             exec 'so '.s:path.'/ngerman'
         endif
     endif


### PR DESCRIPTION
Like I already did in #10 for German language variants, I now implemented the use of utf quote symbols with English languages, when available.