### PR TITLE
Adding support to bibfiles in relative paths / Adding support for nllabel's mark from algorithm2e

### DIFF
--- a/ftplugin/latex-suite/bibtools.py
+++ b/ftplugin/latex-suite/bibtools.py
@@ -4,6 +4,7 @@
 
 import re
 import urllib
+import os
 
 
 class Bibliography(dict):
@@ -171,7 +172,11 @@ class BibFile:
                 self.addfile(f)
 
     def addfile(self, file):
+        if(file[0] == "."):
+            file = os.path.abspath(file)
+
         fields = urllib.urlopen(file).read().split('@')
+
         for f in fields:
             if not (f and re.match('string', f, re.I)):
                 continue

--- a/ftplugin/latex-suite/brackets.vim
+++ b/ftplugin/latex-suite/brackets.vim
@@ -115,10 +115,10 @@ endfunction " }}}
 
 " Provide <plug>'d mapping for easy user customization. {{{
 inoremap <silent> <Plug>Tex_MathBF      <C-r>=Tex_MathBF()<CR>
-inoremap <silent> <Plug>Tex_MathCal     <C-r>=Tex_MathCal()<CR>
+"inoremap <silent> <Plug>Tex_MathCal     <C-r>=Tex_MathCal()<CR>
 inoremap <silent> <Plug>Tex_LeftRight   <C-r>=Tex_LeftRight()<CR>
 vnoremap <silent> <Plug>Tex_MathBF		<C-C>`>a}<Esc>`<i\mathbf{<Esc>
-vnoremap <silent> <Plug>Tex_MathCal		<C-C>`>a}<Esc>`<i\mathcal{<Esc>
+"vnoremap <silent> <Plug>Tex_MathCal		<C-C>`>a}<Esc>`<i\mathcal{<Esc>
 nnoremap <silent> <Plug>Tex_LeftRight	:call Tex_PutLeftRight()<CR>
 
 " }}}
@@ -126,10 +126,10 @@ nnoremap <silent> <Plug>Tex_LeftRight	:call Tex_PutLeftRight()<CR>
 function! <SID>Tex_SetBracketingMaps()
 
 	call Tex_MakeMap('<M-b>', '<Plug>Tex_MathBF', 'i', '<buffer> <silent>')
-	call Tex_MakeMap('<M-c>', '<Plug>Tex_MathCal', 'i', '<buffer> <silent>')
+	"call Tex_MakeMap('<M-c>', '<Plug>Tex_MathCal', 'i', '<buffer> <silent>')
 	call Tex_MakeMap('<M-l>', '<Plug>Tex_LeftRight', 'i', '<buffer> <silent>')
 	call Tex_MakeMap('<M-b>', '<Plug>Tex_MathBF', 'v', '<buffer> <silent>')
-	call Tex_MakeMap('<M-c>', '<Plug>Tex_MathCal', 'v', '<buffer> <silent>')
+	"call Tex_MakeMap('<M-c>', '<Plug>Tex_MathCal', 'v', '<buffer> <silent>')
 	call Tex_MakeMap('<M-l>', '<Plug>Tex_LeftRight', 'n', '<buffer> <silent>')
 
 endfunction

--- a/ftplugin/latex-suite/envmacros.vim
+++ b/ftplugin/latex-suite/envmacros.vim
@@ -947,10 +947,10 @@ inoremap <script> <silent> <Plug>Tex_InsertItemOnNextLine <ESC>o<C-R>=Tex_Insert
 
 function! Tex_SetItemMaps()
 	if !hasmapto("<Plug>Tex_InsertItemOnThisLine", "i")
-		imap <buffer> <M-i> <Plug>Tex_InsertItemOnThisLine
+		"imap <buffer> <M-i> <Plug>Tex_InsertItemOnThisLine
 	endif
 	if !hasmapto("<Plug>Tex_InsertItemOnNextLine", "i")
-		imap <buffer> <C-CR> <Plug>Tex_InsertItemOnNextLine
+		"imap <buffer> <C-CR> <Plug>Tex_InsertItemOnNextLine
 	endif
 endfunction " }}}
 

--- a/ftplugin/latex-suite/outline.py
+++ b/ftplugin/latex-suite/outline.py
@@ -81,11 +81,11 @@ def getSectionLabels_Root(lineinfo, section_prefix, label_prefix):
         line = m.group(2).lstrip()
 
         # we found a label!
-        m = re.search(r'\\label{(%s.*?)}' % label_prefix, line)
+        m = re.search(r'\\(label|nllabel){(%s.*?)}' % label_prefix, line)
         if m:
             # add the current line (except the \label command) to the text
             # which will be displayed below this label
-            prev_txt += re.search(r'(^.*?)\\label{', line).group(1)
+            prev_txt += re.search(r'(^.*?)\\(label|nllabel){', line).group(1)
 
             # for the figure environment however, just display the caption.
             # instead of everything since the \begin command.
@@ -101,7 +101,7 @@ def getSectionLabels_Root(lineinfo, section_prefix, label_prefix):
             #
             # Use the current "section depth" for the leading indentation.
             print >>outstr, '>%s%s\t\t<%s>' % (' ' * (2 * pres_depth + 2),
-                                               m.group(1), fname)
+                                               m.group(2), fname)
             print >>outstr, ':%s%s' % (' ' * (2 * pres_depth + 4), prev_txt)
             prev_txt = ''
 
@@ -115,7 +115,7 @@ def getSectionLabels_Root(lineinfo, section_prefix, label_prefix):
             prev_env = re.search(r'\\begin{(.*?)}', line).group(1)
             inside_env = 1
 
-        elif re.search(r'\\label', line):
+        elif re.search(r'\\(label|nllabel)', line):
             prev_txt = ''
 
         elif re.search(r'\\end{(equation|eqnarray|align|figure)', line):

--- a/ftplugin/latex-suite/texviewer.vim
+++ b/ftplugin/latex-suite/texviewer.vim
@@ -81,13 +81,13 @@ function! Tex_Complete(what, where)
 			elseif Tex_GetVarValue('Tex_UseSimpleLabelSearch') == 1
 				call Tex_Debug("Tex_Complete: searching for \\labels in all .tex files in the present directory", "view")
 				call Tex_Debug("Tex_Complete: silent! grep! ".Tex_EscapeForGrep('\\label{'.s:prefix)." *.tex", 'view')
-				call Tex_Grep('\\label{'.s:prefix, '*.tex')
+				call Tex_Grep('\\label{\|\\nllabel{'.s:prefix, '*.tex')
 				call <SID>Tex_SetupCWindow()
 
 			elseif Tex_GetVarValue('Tex_ProjectSourceFiles') != ''
 				call Tex_Debug('Tex_Complete: searching for \\labels in all Tex_ProjectSourceFiles', 'view')
 				exec 'cd '.fnameescape(Tex_GetMainFileName(':p:h'))
-				call Tex_Grep('\\label{'.s:prefix, Tex_GetVarValue('Tex_ProjectSourceFiles'))
+				call Tex_Grep('\\label{\|\\nllabel{'.s:prefix, Tex_GetVarValue('Tex_ProjectSourceFiles'))
 				call <SID>Tex_SetupCWindow()
 
 			else
@@ -387,7 +387,7 @@ function! s:Tex_CompleteRefCiteCustom(type)
 		let completeword = bibkey
 
 	elseif a:type =~ 'ref'
-		let label = matchstr(getline('.'), '\\label{\zs.\{-}\ze}')
+		let label = matchstr(getline('.'), '\\label{\zs.\{-}\ze}\|\\nllabel{\zs.\{-}\ze}')
 		let completeword = label
 
 	elseif a:type =~ '^plugin_'
@@ -552,15 +552,17 @@ function! Tex_ScanFileForCite(prefix)
 	" First find out if this file has a \(no)bibliography or a \addbibresource
 	" (biblatex) command in it. If so, assume that this is the only file
 	" in the project which defines a bibliography.
-	if search('\\\(\(no\)\?bibliography\|addbibresource\(\[.*\]\)\?\){', 'w')
+	if search('\(%.*\)\@<!\\\(\(no\)\?bibliography\|addbibresource\(\[.*\]\)\?\){', 'w')
 		call Tex_Debug('Tex_ScanFileForCite: found bibliography command in '.bufname('%'), 'view')
 		" convey that we have found a bibliography command. we do not need to
 		" proceed any further.
 		let foundCiteFile = 1
 
 		" extract the bibliography filenames from the command.
-		let bibnames = matchstr(getline('.'), '\\\(\(no\)\?bibliography\|addbibresource\(\[.*\]\)\?\){\zs.\{-}\ze}')
+        let bibblock = join(getline(line('.'), line('$')))
+		let bibnames = matchstr(bibblock, '\\\(\(no\)\?bibliography\|addbibresource\(\[.*\]\)\?\){\zs.\{-}\ze}')
 		let bibnames = substitute(bibnames, '\s', '', 'g')
+		let bibnames = substitute(bibnames, '%', '', 'g')
 
 		call Tex_Debug('trying to search through ['.bibnames.']', 'view')
 
@@ -662,7 +664,7 @@ function! Tex_ScanFileForLabels(prefix)
 	call Tex_Debug("+Tex_ScanFileForLabels: grepping in file [".bufname('%')."]", "view")
 
 	exec 'lcd'.fnameescape(expand('%:p:h'))
-	call Tex_Grepadd('\\label{'.a:prefix, "%")
+	call Tex_Grepadd('\\label{\|\\nllabel{'.a:prefix, "%")
 
 	" Then recursively grep for all \include'd or \input'ed files.
 	exec 0
@@ -839,13 +841,16 @@ function! Tex_FindBibFiles()
 	new
 	exec 'e ' . fnameescape(mainfname)
 
-	if search('\\\(\(no\)\?bibliography\|addbibresource\(\[.*\]\)\?\){', 'w')
+	if search('\(%.*\)\@<!\\\(\(no\)\?bibliography\|addbibresource\(\[.*\]\)\?\){', 'w')
 
 		call Tex_Debug('Tex_FindBibFiles: found bibliography command in '.bufname('%'), 'view')
 
 		" extract the bibliography filenames from the command.
-		let bibnames = matchstr(getline('.'), '\\\(\(no\)\?bibliography\|addbibresource\(\[.*\]\)\?\){\zs.\{-}\ze}')
+        let bibblock = join(getline(line('.'), line('$')))
+		"let bibnames = matchstr(getline('.'), '\\\(\(no\)\?bibliography\|addbibresource\(\[.*\]\)\?\){\zs.\{-}\ze}')
+		let bibnames = matchstr(bibblock, '\\\(\(no\)\?bibliography\|addbibresource\(\[.*\]\)\?\){\zs.\{-}\ze}')
 		let bibnames = substitute(bibnames, '\s', '', 'g')
+		let bibnames = substitute(bibnames, '%', '', 'g')
 
 		call Tex_Debug(':Tex_FindBibFiles: trying to search through ['.bibnames.']', 'view')
 

--- a/ftplugin/latex-suite/texviewer.vim
+++ b/ftplugin/latex-suite/texviewer.vim
@@ -559,7 +559,7 @@ function! Tex_ScanFileForCite(prefix)
 		let foundCiteFile = 1
 
 		" extract the bibliography filenames from the command.
-        let bibblock = join(getline(line('.'), line('$')))
+		let bibblock = join(getline(line('.'), line('$')))
 		let bibnames = matchstr(bibblock, '\\\(\(no\)\?bibliography\|addbibresource\(\[.*\]\)\?\){\zs.\{-}\ze}')
 		let bibnames = substitute(bibnames, '\s', '', 'g')
 		let bibnames = substitute(bibnames, '%', '', 'g')
@@ -846,7 +846,7 @@ function! Tex_FindBibFiles()
 		call Tex_Debug('Tex_FindBibFiles: found bibliography command in '.bufname('%'), 'view')
 
 		" extract the bibliography filenames from the command.
-        let bibblock = join(getline(line('.'), line('$')))
+		let bibblock = join(getline(line('.'), line('$')))
 		"let bibnames = matchstr(getline('.'), '\\\(\(no\)\?bibliography\|addbibresource\(\[.*\]\)\?\){\zs.\{-}\ze}')
 		let bibnames = matchstr(bibblock, '\\\(\(no\)\?bibliography\|addbibresource\(\[.*\]\)\?\){\zs.\{-}\ze}')
 		let bibnames = substitute(bibnames, '\s', '', 'g')


### PR DESCRIPTION
# Motivation for bibfiles in relative paths

Some people, as me, has a large collection of bibfiles (I have 25 bibfiles more or less organized by subject). This bibfiles are used across a number of documents with shared authorship. So, each document has its own folder structure and, to avoid to much messy, the bibfiles are copy/linked in some subfolder, say, `bibfiles`. Since each author has his/her own Latex setup/"way to deal with", the master document includes the bibfiles using relative paths, so that a simple/single command can compile the document. One typical bibliographical entry are:

``` latex
\bibliography{./bibfiles/file1, ./bibfiles/file2}
```

or in case of a large number of bibfiles:

``` latex
% Hope be in alphabetical order
\bibliography{%
./bibfiles/file1,%
./bibfiles/file2,%
./bibfiles/file3%
}
```

The current version of vim-latex does support neither relative paths nor bibfiles listed on single lines. This patch/pull intend to add such feature.
# Details

Two modifications were necessary. The first modification was made when scanning the document for `\bibliography` entry. Instead to fetch only the line with `\bibliography` entry, we fetch all line from the
entry until the end of the document. This maybe not be the best approach, but we supposed that we do not know how many bibfiles we have. Note that, besides the white spaces, we must throw the `%`s way.
This is accomplished with the following modifications on `ftplugin/latex-suite/texviewer.vim`:

``` vim
let bibblock = join(getline(line('.'), line('$')))
let bibnames = matchstr(bibblock, '\\\(\(no\)\?bibliography\|addbibresource\(\[.*\]\)\?\){\zs.\{-}\ze}')
let bibnames = substitute(bibnames, '\s', '', 'g')
let bibnames = substitute(bibnames, '%', '', 'g')
```

Second modification is in reading the bibfiles. The Python `urllib` does not support open files with relative paths. Therefore, we include the following modification to get the absolute path:

``` python
def addfile(self, file):
    if(file[0] == "."):
        file = os.path.abspath(file)
    fields = urllib.urlopen(file).read().split('@')
```

The other minor modifications can be seen in the full pull request.
# Motivation for bibfiles in nllabel's from algorithm2e package

The package algorith2e is designed to write nice algorithms. Using this package, we can label the lines of an algorithm using "nllabel" command. This commit adds support to such labels.
