### PR TITLE
Enable Tex_Folding without Tex_AutoFolding

### DIFF
--- a/ftplugin/latex-suite/folding.vim
+++ b/ftplugin/latex-suite/folding.vim
@@ -25,8 +25,11 @@ function! Tex_SetFoldOptions()
 
 	setlocal foldtext=TexFoldTextFunction()
 
-	if g:Tex_Folding && g:Tex_AutoFolding
+	if g:Tex_Folding
 		call MakeTexFolds(0)
+		if !g:Tex_AutoFolding
+			normal! zR
+		endif
 	endif
 
 	let s:ml = '<Leader>'


### PR DESCRIPTION
When Tex_Folding is enabled and Tex_AutoFolding is disabled, trying
to fold TeX causes vim to output: No fold found. The reason is that
MakeTexFolds is not called when Tex_AutoFolding is disabled. This
branch simply calls zR to prevent auto folding.