### PR TITLE
Fixed two bugs in bibtex support and forward searching on windows with SumatraPDF

### DIFF
--- a/ftplugin/latex-suite/compiler.vim
+++ b/ftplugin/latex-suite/compiler.vim
@@ -368,7 +368,7 @@ function! Tex_ForwardSearchLaTeX()
 		elseif (viewer =~? "^sumatrapdf")
 			" Forward search in sumatra has these arguments (-reuse-instance is optional):
 			" SumatraPDF -reuse-instance "pdfPath" -forward-search "texPath" lineNumber
-			let execString .= Tex_Stringformat('start %s "%s" -forward-search "%s" %s', viewer, target_file, mainfnameFull.".tex", linenr)
+			let execString .= Tex_Stringformat('start %s "%s" -forward-search "%s" %s', viewer, target_file, sourcefileFull, linenr)
 		endif	
 
 	elseif (has('macunix') && (viewer =~ '^ *\(Skim\|PDFView\|TeXniscope\)\( \|$\)'))

--- a/ftplugin/latex-suite/compiler.vim
+++ b/ftplugin/latex-suite/compiler.vim
@@ -591,7 +591,7 @@ function! Tex_CompileMultipleTimes()
 		" The first time we see if we need to generate the bibliography and if the .bbl file
 		" changes, we will rerun latex.
 		" We use '\\bibdata' as a check for BibTeX and '\\abx' as a check for biber.
-		if runCount == 0 && Tex_IsPresentInFile('\v\\bibdata|\\abx', mainFileName_root.'.aux')
+		if runCount == 0 && Tex_IsPresentInFile('\\bibdata|\\abx', mainFileName_root.'.aux')
 			let bibFileName = mainFileName_root.'.bbl'
 
 			let biblinesBefore = Tex_CatFile(bibFileName)


### PR DESCRIPTION
1. Fixed regexp in search of bibdata.
2. Fixed a bug in Tex_ForwardSearchLaTeX() when multiple tex file is used for SumatraPDF viewer on windows.
