### PR TITLE
tfrac completion with both arguments

### DIFF
--- a/ftplugin/latex-suite/envmacros.vim
+++ b/ftplugin/latex-suite/envmacros.vim
@@ -970,6 +970,7 @@ endfunction " }}}
 
 TexLet g:Tex_Com_{'newtheorem'} = '\newtheorem{<+name+>}{<+caption+>}[<+within+>]'
 TexLet g:Tex_Com_{'frac'} = '\frac{<+n+>}{<+d+>}<++>'
+TexLet g:Tex_Com_{'tfrac'} = '\tfrac{<+n+>}{<+d+>}<++>'
 
 " }}}
 " PromptForCommand: prompts for a command {{{


### PR DESCRIPTION
tiny-fractures are quite useful for inline math not to blow up line height; so I'm using these often. I propose to add completion for \tfrac{}{} rather than \tfrac{}. Behaviour is the the same as for frac.