### PR TITLE
Improved folding feature

### DIFF
--- a/doc/latex-suite.txt
+++ b/doc/latex-suite.txt
@@ -1889,8 +1889,8 @@ i.e newly created syntax items are not automatically folded up. (This is a
 compromise between speed and convenience).
 
 When you open up a LaTeX file, all the portions will be automatically folded up.
-However, no new folds will be created until you press <F6> or \rf. (rf stands
-for "refresh folds").
+However, no new folds will be created until you press \rf. (rf stands for
+"refresh folds").
 
 The fold-text is set to the first line of the folded text unless the fold is a
 table, figure etc. (an environment). In this case, if a \caption and/or a label
@@ -1919,20 +1919,28 @@ will be shown as:  >
 Default Folding Scheme in Latex-Suite                         *ls_8_1* *ls_a_cj*
                                                                *default-folding*
 
-By default Latex-Suite creates folds in the following manner:
+By default, Latex-Suite creates folds in the following manner:
 
   >
-    \chapter
-    \section
-    %%fakesection
-        \subsection
-            \subsubsection
-                \item
-                    \equation
-                    \eqnarray
-                    \figure
-                    \table
-                    \footnote
+    
+    \part
+    %%fakepart
+        \chapter
+        %%fakechapter
+            \section
+            %%fakesection
+                \subsection
+                %%fakesubsection
+                    \subsubsection
+                    %%fakesubsubsection
+                        \paragraph
+                        %%fakeparagraph
+                            \item
+                                \equation
+                                \eqnarray
+                                \figure
+                                \table
+                                \footnote
 The indentation shows the "nestedness" of the folding scheme. See the next
 section [|ls_a_ck|] to see how you can change this scheme.
 
@@ -1950,13 +1958,25 @@ Tex_FoldedSections                                          *ls_8_2_1* *ls_a_cl*
 
 This entry defines which sections will be folded. This setting is a comma
 separated list of section names. The default value is:  >
-    part,chapter,section,%%fakesection,
-    subsection,subsubsection,paragraph
-Each of the entries in the list will fold up a section of the corresponding
-name. The %%fakesection section is provided as a means for the user to group
-lines into "fake" sections. A %%fakesection is assumed to start on a line which
-begins with the string %%fakesection and continue till the start of the next
-\section, \subsection or any other section.
+    part,chapter,section,subsection,subsubsection,paragraph
+Each of the entries in the list will fold up a section of the corresponding name
+and the corresponding %%fakesection. The %%fakesection section is provided as a
+means for the user to group lines into "fake" sections. In particular, it is
+useful to fold the introduction of a section that is not part of a subsection:  >
+    
+    \section{Latex-Suite}
+    %%fakesubsection Introduction
+    A short introduction of the features of Latex-Suite.
+    \subsection{Installation}
+    Installation instructions.
+Without the %%fakesubsection the introduction would not be folded separately
+from the section.
+
+It is also possible, to add section names at the same level of hierarchy. These
+have to be separated by "|". This is, e.g., useful for the KOMA classes, which
+add "\addcap":  >
+    " let g:Tex_FoldedSections = 'part|addpart,chapter|addchap,section|addsec,subsection,subsubsection,paragraph,subparagraph'
+
 
 See also advanced fold settings [|ls_a_cp|].
 
@@ -3344,7 +3364,7 @@ Folding Customization                                        *ls_11_9* *ls_a_dQ*
                                                            *customizing-folding*
 
 The following settings control the folding [|ls_a_ci|] functionality of
-Latex-Suite.
+Latex-Suite, see also Customizing what to fold [|ls_a_ck|].
 
 
 

--- a/doc/latex-suite.xml
+++ b/doc/latex-suite.xml
@@ -2356,7 +2356,7 @@ let g:Tex_CompileRule_pdf = 'ps2pdf $*.ps'</programlisting>
   <para>
    When you open up a LaTeX file, all the portions will be automatically folded
    up. However, no new folds will be created until you press
-   <literal>&lt;F6&gt;</literal> or <literal>\rf</literal>. (rf
+   <literal>\rf</literal>. (rf
    stands for "refresh folds").
   </para>
   <para>
@@ -2384,19 +2384,27 @@ let g:Tex_CompileRule_pdf = 'ps2pdf $*.ps'</programlisting>
   <section id="default-folding">
    <title>Default Folding Scheme in &ls;</title>
    <para>
-    By default &ls; creates folds in the following manner:
+    By default, &ls; creates folds in the following manner:
    </para>
-   <programlisting>\chapter
-\section
-%%fakesection
-    \subsection
-        \subsubsection
-            \item
-                \equation
-                \eqnarray
-                \figure
-                \table
-                \footnote</programlisting>
+   <programlisting>
+\part
+%%fakepart
+    \chapter
+    %%fakechapter
+        \section
+        %%fakesection
+            \subsection
+            %%fakesubsection
+                \subsubsection
+                %%fakesubsubsection
+                    \paragraph
+                    %%fakeparagraph
+                        \item
+                            \equation
+                            \eqnarray
+                            \figure
+                            \table
+                            \footnote</programlisting>
    <para>
     The indentation shows the "nestedness" of the folding scheme.
     See the <link linkend="customizing-what-to-fold">next section</link> to
@@ -2415,15 +2423,27 @@ let g:Tex_CompileRule_pdf = 'ps2pdf $*.ps'</programlisting>
      This entry defines which sections will be folded. This
      setting is a comma separated list of section names. 
      The default value is:
-     <programlisting>part,chapter,section,%%fakesection,
-subsection,subsubsection,paragraph</programlisting>
+     <programlisting>part,chapter,section,subsection,subsubsection,paragraph</programlisting>
      Each of the entries in the list will fold up a section of the
-     corresponding name. The <literal>%%fakesection</literal> section is
+     corresponding name and the corresponding <literal>%%fakesection</literal>.
+     The <literal>%%fakesection</literal> section is
      provided as a means for the user to group lines into "fake" sections.
-     A <literal>%%fakesection</literal> is assumed to start on a line which
-     begins with the string <literal>%%fakesection</literal> and continue
-     till the start of the next <literal>\section</literal>,
-     <literal>\subsection</literal> or any other section.
+     In particular, it is useful to fold the introduction of a <literal>section</literal>
+     that is not part of a <literal>subsection</literal>:
+     <programlisting>
+\section{Latex-Suite}
+%%fakesubsection Introduction
+A short introduction of the features of Latex-Suite.
+\subsection{Installation}
+Installation instructions.</programlisting>
+     Without the <literal>%%fakesubsection</literal> the introduction would not be folded separately from the section.
+    </para>
+    <para>
+      It is also possible, to add section names at the same
+      level of hierarchy. These have to be separated by "|".
+      This is, e.g., useful for the KOMA classes, which add
+      "\addcap":
+      <programlisting>" let g:Tex_FoldedSections = 'part|addpart,chapter|addchap,section|addsec,subsection,subsubsection,paragraph,subparagraph'</programlisting>
     </para>
     <para>
      See also <link linkend="fold-setting-advanced">advanced fold
@@ -4468,7 +4488,8 @@ let g:Tex_ViewRuleComplete_html = 'start MozillaFirebird $*/index.html'</program
    <title>Folding Customization</title>
    <para>
     The following settings control the <link
-     linkend="latex-folding">folding</link> functionality of &ls;.
+     linkend="latex-folding">folding</link> functionality of &ls;,
+    see also <link linkend="customizing-what-to-fold">Customizing what to fold</link>.
    </para>
    <section id="Tex_Folding">
     <title>g:Tex_Folding</title>

--- a/ftplugin/latex-suite/folding.vim
+++ b/ftplugin/latex-suite/folding.vim
@@ -1,7 +1,7 @@
 "=============================================================================
 " 	     File: folding.vim
 "      Author: Srinath Avadhanula
-"      		   modifications/additions by Zhang Linbo
+"      		   modifications/additions by Zhang Linbo, Gerd Wachsmuth
 "     Created: Tue Apr 23 05:00 PM 2002 PST
 " 
 "  Description: functions to interact with Syntaxfolds.vim
@@ -38,7 +38,6 @@ function! Tex_SetFoldOptions()
 
 endfunction " }}}
 " Tex_FoldSections: creates section folds {{{
-" Author: Zhang Linbo
 " Description:
 " 	This function takes a comma seperated list of "sections" and creates fold
 " 	definitions for them. The first item is supposed to be the "shallowest" field
@@ -58,17 +57,19 @@ function! Tex_FoldSections(lst, endpat)
 	else
 		let pattern = ''
 		let prefix = ''
-		for label in split(s, "|")
-			let pattern .= prefix . '^\s*\\' . label . '\W\|^\s*%%fake' . label
-			let prefix = '\W\|'
+		for label in split( s, "|" )
+			let pattern .= prefix . '\\' . label . '\|' . '%%fake' . label
+			let prefix = '\|'
 		endfor
-		let s = pattern
+		" The line before the pattern could contain a mixture of "% =_" (within a
+		" comment).
+		" The pattern itself is ended by a non-word character "\W" or a newline.
+		let s = '^\%(%[% =-]*\n\)\?\s*' . '\%(' . pattern . '\)' . '\%(\W\|\n\)'
 	endif
 	let endpat = s . '\|' . a:endpat
 	if i > 0
 		call Tex_FoldSections(strpart(a:lst,i+1), endpat)
 	endif
-	let endpat = '^\s*\\appendix\W\|' . endpat
 	call AddSyntaxFoldItem(s, endpat, 0, -1)
 endfunction
 " }}}
@@ -108,7 +109,7 @@ function! MakeTexFolds(force)
 	" requires a regexp which will match unbalanced curly braces and that is
 	" apparently not doable with regexps.
 	let s = ''
-    if !exists('g:Tex_FoldedCommands')
+	if !exists('g:Tex_FoldedCommands')
 		let g:Tex_FoldedCommands = s
 	elseif g:Tex_FoldedCommands[0] == ','
 		let g:Tex_FoldedCommands = s . g:Tex_FoldedCommands
@@ -118,7 +119,7 @@ function! MakeTexFolds(force)
 
 	let s = 'verbatim,comment,eq,gather,align,figure,table,thebibliography,'
 			\. 'keywords,abstract,titlepage'
-    if !exists('g:Tex_FoldedEnvironments')
+	if !exists('g:Tex_FoldedEnvironments')
 		let g:Tex_FoldedEnvironments = s
 	elseif g:Tex_FoldedEnvironments[0] == ','
 		let g:Tex_FoldedEnvironments = s . g:Tex_FoldedEnvironments
@@ -126,7 +127,7 @@ function! MakeTexFolds(force)
 		let g:Tex_FoldedEnvironments = g:Tex_FoldedEnvironments . s
 	endif
 	
-    if !exists('g:Tex_FoldedSections')
+	if !exists('g:Tex_FoldedSections')
 		let g:Tex_FoldedSections = 'part,chapter,section,'
 								\. 'subsection,subsubsection,paragraph'
 	endif
@@ -292,7 +293,12 @@ function! MakeTexFolds(force)
 					" In other words, the pattern is safe, but not exact.
 					call AddSyntaxFoldItem('^\s*\\'.s.'{[^{}]*$','^[^}]*}',0,0)
 				else
-					call AddSyntaxFoldItem('^\s*\\begin{'.s,'\(^\|\s\)\s*\\end{'.s,0,0)
+					if s =~ 'itemize\|enumerate\|description'
+						" These environments can nest.
+						call AddSyntaxFoldItem('^\s*\\begin{'.s,'\(^\|\s\)\s*\\end{'.s,0,0,'^\s*\\begin{'.s,'\(^\|\s\)\s*\\end{'.s)
+					else
+						call AddSyntaxFoldItem('^\s*\\begin{'.s,'\(^\|\s\)\s*\\end{'.s,0,0,'','')
+					endif
 				endif
 			endif
 		endwhile
@@ -303,9 +309,10 @@ function! MakeTexFolds(force)
 	" Sections {{{
 	if g:Tex_FoldedSections != '' 
 		call Tex_FoldSections(g:Tex_FoldedSections,
-			\ '^\s*\\frontmatter\|^\s*\\mainmatter\|^\s*\\backmatter\|'
+			\ '^\s*\\\%(frontmatter\|mainmatter\|backmatter\)\|'
 			\. '^\s*\\begin{thebibliography\|>>>\|^\s*\\endinput\|'
-			\. '^\s*\\begin{slide\|^\s*\\end{document')
+			\. '^\s*\\begin{slide\|^\s*\\\%(begin\|end\){document\|'
+			\. '^\s*\\\%(\%(begin\|end\){appendix}\|appendix\)')
 	endif
 	" }}} 
 	
@@ -343,16 +350,25 @@ function! MakeTexFolds(force)
 	" }}}
 	
 	call MakeSyntaxFolds(a:force)
-	normal! zv
 endfunction
 
 " }}}
 " TexFoldTextFunction: create fold text for folds {{{
 function! TexFoldTextFunction()
-	let leadingSpace = matchstr('                                       ', ' \{,'.indent(v:foldstart).'}')
+	" The dashes indicating the foldlevel together with
+	" the number of lines are aligned to width '7'.
+	let lines = v:foldend - v:foldstart + 1
+	let myfoldtext = repeat('-', v:foldlevel-1) . '+'
+				\. repeat(' ', 7-(v:foldlevel-1)-len(lines))
+				\. lines . ' lines: '
+
+	" Add some indent per foldlevel
+	let myfoldtext .= repeat('> ', v:foldlevel-1)
+
 	if getline(v:foldstart) =~ '^\s*\\begin{'
 		let header = matchstr(getline(v:foldstart),
 							\ '^\s*\\begin{\zs\([:alpha:]*\)[^}]*\ze}')
+		let title = ''
 		let caption = ''
 		let label = ''
 		let i = v:foldstart
@@ -373,29 +389,59 @@ function! TexFoldTextFunction()
 				" :FIXME: this does not work when \label contains a
 				" newline or a }-character
 				let label = substitute(label, '\([^}]*\)}.*$', '\1', '')
+			elseif header =~ 'frame' && getline(i) =~ '\\begin{frame}.*{[^{}]*}\|\\frametitle\|%'
+				if getline(i) =~ '\\begin{frame}'
+					" The first argument inside {} is the frame title (the
+					" second one is a subtitle)
+					let title = matchstr(getline(i), '\\begin{frame}.\{-}{\zs[^{}]*\ze}')
+				elseif getline(i) =~ '\\frametitle'
+					let title = matchstr(getline(i), '\\frametitle{\zs[^}]*\ze}')
+				elseif getline(i) =~ '%' && title == ''
+					let title = substitute(getline(i), '^\(\s\|%\)*', '', '')
+				endif
 			end
 
 			let i = i + 1
 		endwhile
 
-		let ftxto = foldtext()
+		if header =~ 'frame'
+			if title == ''
+				let title = getline(v:foldstart + 1)
+			end
+			" Count frames
+			let frnum = 0
+			for line in getline(1,v:foldstart)
+				if line =~ '\\begin{frame}'
+					let frnum=frnum+1
+				endif
+			endfor
+			" Pad with spaces to length 2
+			let frnum = repeat(' ', 2-len(frnum)) . frnum
+			return myfoldtext . ': Frame ' . frnum . ': ' . title
+		end
+
 		" if no caption found, then use the second line.
 		if caption == ''
 			let caption = getline(v:foldstart + 1)
 		end
 
-		let retText = matchstr(ftxto, '^[^:]*').': '.header.
-						\ ' ('.label.'): '.caption
-		return leadingSpace.retText
+		return myfoldtext . header.  ' ('.label.'): '.caption
 
-	elseif getline(v:foldstart) =~ '^%' && getline(v:foldstart) !~ '^%%fake'
-		let ftxto = foldtext()
-		return leadingSpace.substitute(ftxto, ':', ': % ', '')
+	elseif getline(v:foldstart) =~ '^\s*%\+[% =-]*$'
+		" Useless comment. Use the next line.
+		return myfoldtext . getline(v:foldstart+1)
+	elseif getline(v:foldstart) =~ '^\s*%%fake'
+		" Just strip one '%' from the fakesection.
+		return myfoldtext . substitute(getline(v:foldstart), '^\s*%%fake', '%', '')
+	elseif getline(v:foldstart) =~ '^\s*%'
+		" It's any other comment. Use it.
+		return myfoldtext . getline(v:foldstart)
 	elseif getline(v:foldstart) =~ '^\s*\\document\(class\|style\).*{'
-		let ftxto = leadingSpace.foldtext()
-		return substitute(ftxto, ':', ': Preamble: ', '')
+		" This is the preamble.
+		return myfoldtext . 'Preamble: ' . getline(v:foldstart)
 	else
-		return leadingSpace.foldtext()
+		" This is something.
+		return myfoldtext . getline(v:foldstart)
 	end
 endfunction
 " }}}

--- a/ftplugin/latex-suite/texrc
+++ b/ftplugin/latex-suite/texrc
@@ -728,7 +728,7 @@ TexLet g:Tex_Folding = 1
 " Setting this to zero means that a file is not folded up as soon as its
 " opened.
 " NOTE: the MakeTeXFolds() function will still be available (unless disabled
-"       by g:Tex_Folding), so you can do <F6> or \rf to refresh/create folds.
+"       by g:Tex_Folding), so you can do \rf to refresh/create folds.
 TexLet g:Tex_AutoFolding = 1 
 
 " }}}


### PR DESCRIPTION
This pull request should improve the folding feature of latex-suite:
- Improved(?) the foldtext
- Itemize environments can nest
- Replaced a stack implementation by vim lists
- Add some debugging code to SyntaxFolds.vim
- Removed some bugs
- Speedup of folding

Please test, whether this works for you. Let me know, if you find some bugs or some weird behaviour for your documents.