### PR TITLE
fixed s:LookupCharacter("\<C-\>")

### DIFF
--- a/plugin/imaps.vim
+++ b/plugin/imaps.vim
@@ -295,7 +295,7 @@ function! s:LookupCharacter(char)
 	" character typed:
 	let bs = substitute(s:MultiByteStrpart(lhs, 1), ".", "\<bs>", "g")
 	" \<c-g>u inserts an undo point
-	return a:char . "\<c-g>u\<bs>" . bs . IMAP_PutTextWithMovement(rhs, phs, phe)
+	return "\<c-v>" . a:char . "\<c-g>u\<bs>" . bs . IMAP_PutTextWithMovement(rhs, phs, phe)
 endfunction
 
 " }}}


### PR DESCRIPTION
Literally input `a:char` to avoid unexpected mappings.
For example, `i_CTRL-\_CTRL-G` can switch the mode and break the sequence.

I found this bug when trying to use `IMAP` with `lhs` ending with `<C-\>`.