### PR TITLE
Fixed bug where tex includes with spaces would be ignored by outline parsing

### DIFF
--- a/ftplugin/latex-suite/outline.py
+++ b/ftplugin/latex-suite/outline.py
@@ -34,7 +34,7 @@ def getFileContents(fname):
         return ''
 
     # TODO what are all the ways in which a tex file can include another?
-    pat = re.compile(r'^\\(@?)(include|input){(.*?)}', re.M)
+    pat = re.compile(r'^\s*\\(@?)(include|input){(.*?)}', re.M)
     contents = re.sub(pat, getFileContents, contents)
 
     return ('%%==== FILENAME: %s' % fname) + '\n' + contents


### PR DESCRIPTION
Dear developers,

first, I would like to thanks the opportunity to thank you for the great work. 

I was having issues when trying to use auto-complete references, it was returning empty lists. I discovered that it was due to my master latex file which had spaced includes, as in:

```
\begin{document}
  \input{extra/simb.tex}
  \input{extra/abrev.tex}
  \mainmatter
  \include{base/intro}
  \include{body/cern}
…
\end{document}
```

I discovered that the parser in the `outline.py` file would not deal with this situation. Thus, I made a small change to consider this situation.

Best,
Werner.