### PR TITLE
Use tab-window as workaround for terminal vim

### DIFF
--- a/ftplugin/latex-suite/compiler.vim
+++ b/ftplugin/latex-suite/compiler.vim
@@ -510,7 +510,11 @@ function! Tex_PartCompile() range
 	exe a:firstline.','.a:lastline."w! >> ".tmpfile
 
 	" edit the temporary file
-	exec 'drop '.tmpfile
+	if exists('drop')
+		exec 'drop '.tmpfile
+	else
+		exec 'tabe '.tmpfile
+	endif
 
 	" append the \end{document} line.
 	$ put ='\end{document}'


### PR DESCRIPTION
Dear developers,
I was having issues to use the part-compile feature in terminal-based vim, as the drop function is not available. As a workaround, I set it to use a new tab.
Hope this helps others to use this functionality as well. Best,
Werner.
