### PR TITLE
Don't execute python commands if Tex_UsePython is false

### DIFF
--- a/ftplugin/latex-suite/texviewer.vim
+++ b/ftplugin/latex-suite/texviewer.vim
@@ -713,7 +713,7 @@ endfunction " }}}
 " get the place where this plugin resides for setting cpt and dict options.
 " these lines need to be outside the function.
 let s:path = expand('<sfile>:p:h')
-if g:Tex_HasPython
+if Tex_UsePython()
 	exec g:Tex_PythonCmd . " import sys, re"
 	exec g:Tex_PythonCmd . " sys.path += [r'". s:path . "']"
 	exec g:Tex_PythonCmd . " import outline"
@@ -892,7 +892,7 @@ endfunction " }}}
 
 " get the place where this plugin resides for setting cpt and dict options.
 " these lines need to be outside the function.
-if g:Tex_HasPython
+if Tex_UsePython()
 	exec g:Tex_PythonCmd . " import sys, re"
 	exec g:Tex_PythonCmd . " sys.path += [r'". s:path . "']"
 	exec g:Tex_PythonCmd . " import bibtools"


### PR DESCRIPTION
It looks like these blocks of Python commands should be conditional on UsePython rather than HasPython. This need is especially acute because there's a bad interaction between Windows Gvim and certain Python distributions (particularly Anaconda).

See for example https://stackoverflow.com/questions/7034254/plugin-vim-latex-crashing-gvim-on-startup. But the workaround on Stack Overflow is "let g:Tex_UsePython=0", which no longer works because texviewer.vim is attempting to run Python commands even when UsePython is false (as long as HasPython is true).

Thus, my fix is to check UsePython instead of HasPython in the two relevant places.