### PR TITLE
ignoring wildignore when looking for .latexmain

### DIFF
--- a/ftplugin/latex-suite/main.vim
+++ b/ftplugin/latex-suite/main.vim
@@ -401,7 +401,7 @@ function! Tex_GetMainFileName(...)
 	" move up the directory tree until we find a .latexmain file.
 	" TODO: Should we be doing this recursion by default, or should there be a
 	"       setting?
-	while glob('*.latexmain') == ''
+	while glob('*.latexmain',v:true) == ''
 		let dirmodifier = dirmodifier.':h'
 		let dirNew = fnameescape(expand(dirmodifier))
 		" break from the loop if we cannot go up any further.
@@ -412,7 +412,7 @@ function! Tex_GetMainFileName(...)
 		exe 'cd '.dirLast
 	endwhile
 
-	let lheadfile = glob('*.latexmain')
+	let lheadfile = glob('*.latexmain',v:true)
 	if lheadfile != ''
 		" Remove the trailing .latexmain part of the filename... We never want
 		" that.
@@ -420,6 +420,7 @@ function! Tex_GetMainFileName(...)
 	else
 		" If we cannot find any main file, just modify the filename of the
 		" current buffer.
+		echo "XXX No found this: ".lheadfile)
 		let lheadfile = expand('%'.modifier)
 	endif
 


### PR DESCRIPTION
Without this, if the user put .latexmain in the wildignore, then
viewing will not work from a file other than main