### PR TITLE
BugFix: Folding: Section Title Parsing

### DIFF
--- a/ftplugin/latex-suite/folding.vim
+++ b/ftplugin/latex-suite/folding.vim
@@ -457,9 +457,8 @@ function! TexFoldTextFunction()
 	if getline(v:foldstart) =~ '^\s*' . section_pattern
 		" This is a section. Search for the content of the mandatory argument {...}
 		let type = matchstr(getline(v:foldstart), '^\s*\zs' . section_pattern)
-		let idx = match(getline(v:foldstart), '^\s*' . section_pattern . '\zs')
 
-		return myfoldtext . type . ParseSectionTitle(v:foldstart, idx)
+		return myfoldtext . type . ParseSectionTitle(v:foldstart)
 	else
 		" This is something.
 		return myfoldtext . getline(v:foldstart)
@@ -469,12 +468,12 @@ endfunction
 " s:ParseSectionTitle: create fold text for sections {{{
 " Search for the mandatory argument of the \section command and ignore the
 " optional argument.
-function! ParseSectionTitle(foldstart, idx)
+function! ParseSectionTitle(foldstart)
 	let currlinenr = a:foldstart
 	let currline = s:StripLine(getline(currlinenr))
 	let currlinelen = strlen(currline)
 
-	let index = a:idx
+	let index = 0
 
 	let maxlines = 10
 
@@ -491,7 +490,7 @@ function! ParseSectionTitle(foldstart, idx)
 			" Read a new line.
 			let maxlines = maxlines - 1
 			if maxlines < 0
-				return string . ' Scanned to many lines'
+				return string . ' Scanned too many lines'
 			endif
 			let currlinenr = currlinenr + 1
 			let currline = s:StripLine(getline(currlinenr))


### PR DESCRIPTION
Previously, if a section began anywhere other than the first column of
the line, then the title of that section would usually be omitted from
the fold summary.

e.g.

```
\documentclass{article}
\begin{document}
\section{This title was always read}
  Lorem ipsum
  \section{This title was not read}
  Lorem ipsum
  \section*{This title was also not read}
  Lorem ipsum
\end{document}
```

This error occurred because of a mismatch in how whitespace was handled
between the fold locator and the section title parser.

Now the section title is always detected.