### PR TITLE
Fix logic to re-open folds if Tex_AutoFolding is disabled

### DIFF
--- a/ftplugin/latex-suite/folding.vim
+++ b/ftplugin/latex-suite/folding.vim
@@ -357,7 +357,7 @@ function! MakeTexFolds(force, manual)
 
 	" Open all folds if this function was triggered automatically
 	" and g:Tex_AutoFolding is disabled
-	if a:manual && !g:Tex_AutoFolding
+	if !a:manual && !g:Tex_AutoFolding
 		normal! zR
 	endif
 endfunction


### PR DESCRIPTION
As per comment MakeTexFolds was not called manually in this case.