### PR TITLE
Fix forward search w/ sumatra with ssl option, keeping ssl on

### DIFF
--- a/ftplugin/latex-suite/compiler.vim
+++ b/ftplugin/latex-suite/compiler.vim
@@ -381,6 +381,10 @@ function! Tex_ForwardSearchLaTeX()
 		elseif (viewer =~? "^sumatrapdf")
 			" Forward search in sumatra has these arguments (-reuse-instance is optional):
 			" SumatraPDF -reuse-instance "pdfPath" -forward-search "texPath" lineNumber
+			if &ssl
+				let sourcefileFull = substitute(sourcefileFull,"'",'"','g')
+				let target_file = substitute(target_file,"'",'"','g')
+			end
 			let execString .= Tex_Stringformat('start %s %s -forward-search %s %s', viewer, target_file, sourcefileFull, linenr)
 		endif	
 


### PR DESCRIPTION
Hi 

I stumbled into #138. I did have shellescape on, and it took me a while to figure out why the forward search was not working. The current fix is somegow less intrusive that what @keighrim  was suggesting: it keep shellescape on (since maybe that's what the user wants), but replaces the single quote with double quotes. 

If you don't like this approach we could throw a warning at the user saying that they should turn shellescape off.


