### PR TITLE
Fixed s:viewer undefined bug for macosx

### DIFF
--- a/ftplugin/latex-suite/compiler.vim
+++ b/ftplugin/latex-suite/compiler.vim
@@ -42,6 +42,7 @@ function! Tex_SetTeXCompilerTarget(type, target)
 
 	elseif Tex_GetVarValue('Tex_'.a:type.'RuleComplete_'.target) != ''
 		let s:target = target
+		let s:viewer = ''
 
 	elseif a:type == 'View' && (has('osx') || has('macunix'))
 				\ && Tex_GetVarValue('Tex_TreatMacViewerAsUNIX') != 1


### PR DESCRIPTION
This commit implements a solution to the bug reported in issue #159.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vim-latex/vim-latex/160)
<!-- Reviewable:end -->
