### PR TITLE
Add support for Alt-<Key> usage in terminal

### DIFF
--- a/ftplugin/latex-suite/envmacros.vim
+++ b/ftplugin/latex-suite/envmacros.vim
@@ -966,6 +966,9 @@ function! Tex_SetItemMaps()
 	" conflicts with inserting 'é'.
 	if !hasmapto("<Plug>Tex_InsertItemOnThisLine", "i") && g:Tex_AdvancedMath == 1
 		imap <buffer> <M-i> <Plug>Tex_InsertItemOnThisLine
+		if !has('gui_running')
+		    imap <buffer> <Esc>i <Plug>Tex_InsertItemOnThisLine
+		endif
 	endif
 	if !hasmapto("<Plug>Tex_InsertItemOnNextLine", "i")
 		imap <buffer> <C-CR> <Plug>Tex_InsertItemOnNextLine

--- a/ftplugin/latex-suite/main.vim
+++ b/ftplugin/latex-suite/main.vim
@@ -585,6 +585,9 @@ endfunction
 function! Tex_MakeMap(lhs, rhs, mode, extraargs)
 	if !hasmapto(a:rhs, a:mode)
 		exec a:mode.'map '.a:extraargs.' '.a:lhs.' '.a:rhs
+		if !has('gui_running') && stridx(a:lhs, '<M-') != -1
+			exec a:mode.'map '.a:extraargs.' '.substitute(a:lhs, '\v\<M-([^\>]+)\>', '<Esc>\1','').' '.a:rhs
+		endif
 	endif
 endfunction " }}}
 " Tex_CD: cds to given directory escaping spaces if necessary {{{


### PR DESCRIPTION
In the GUI environment vim-latex offers many mappings.

Whereas in CLI environment, these mappings will not trigger.

This patch offers a solution for this problem in CLI environments.