### PR TITLE
Fix Tex_GetCurrentEnv

### DIFF
--- a/ftplugin/latex-suite/envmacros.vim
+++ b/ftplugin/latex-suite/envmacros.vim
@@ -902,33 +902,30 @@ endfunction " }}}
 " Author: Albin Ahlbäck
 function! Tex_GetCurrentEnv()
 	let pos = Tex_GetPos()
-	let ix = 0
+	let n = 0
 	while 1
-		let env_line = search('\\\(begin\|end\){', 'bW')
+		let env_line = search('\%(\\\@<!\%(\\\\\)*%.*\)\@<!\\\%(begin\|end\){', 'bW')
 		if env_line == 0
 			" we reached the beginning of the file, so we return the empty string
 			call Tex_SetPos(pos)
 			return ''
 		endif
-		let ia = getcurpos()[2]
-		call search('{')
-		let ib = getcurpos()[2]
-		if getline(env_line)[ia:ib-2] == 'begin'
-			if ix == 0
-				let env_line = search('\w')
-				let ia = getcurpos()[2]
-				call search('\(%\|\_s\)')
-				let ib = getcurpos()[2]
-				call search('\\begin{', 'b')
+		let ix = getcurpos()[2]
+		if getline(env_line)[ix] == 'b'
+			if n == 0
+				let env_line = search('{\%(\|\_s*\)\w', 'e')
+				let ix = getcurpos()[2]
+				call search('\a\>')
+				let iy = getcurpos()[2]
 				call Tex_SetPos(pos)
-				return getline(env_line)[ia-1:ib-2]
+				return getline(env_line)[ix-1:iy-1]
 			else
-				let ix = ix - 1
-				call search('\\begin{', 'b')
+				let n = n - 1
+				call search('\%(\\\@<!\%(\\\\\)*%.*\)\@<!\\begin{', 'b')
 			endif
 		else
-			let ix = ix + 1
-			call search('\\end{', 'b')
+			let n = n + 1
+			call search('\%(\\\@<!\%(\\\\\)*%.*\)\@<!\\end{', 'b')
 		endif
 	endwhile
 endfunction

--- a/ftplugin/latex-suite/envmacros.vim
+++ b/ftplugin/latex-suite/envmacros.vim
@@ -899,32 +899,36 @@ endfunction " }}}
 " 	\end{itemize}
 " 	% Tex_GetCurrentEnv will return "" when called from here 
 "
-" Author: Alan Schmitt
+" Author: Albin Ahlbäck
 function! Tex_GetCurrentEnv()
 	let pos = Tex_GetPos()
-	let i = 0
+	let ix = 0
 	while 1
-		let env_line = search('^[^%]*\\\%(begin\|end\){', 'bW')
+		let env_line = search('\\\(begin\|end\){', 'bW')
 		if env_line == 0
 			" we reached the beginning of the file, so we return the empty string
 			call Tex_SetPos(pos)
 			return ''
 		endif
-		if match(getline(env_line), '^[^%]*\\begin{') == -1
-			" we found a \\end, so we keep searching
-			let i = i + 1
-			continue
-		else
-			" we found a \\begin which has not been \\end'ed. we are done.
-			if i == 0
-				let env = matchstr(getline(env_line), '\\begin{\zs.\{-}\ze}')
+		let ia = getcurpos()[2]
+		call search('{')
+		let ib = getcurpos()[2]
+		if getline(env_line)[ia:ib-2] == 'begin'
+			if ix == 0
+				let env_line = search('\w')
+				let ia = getcurpos()[2]
+				call search('\(%\|\_s\)')
+				let ib = getcurpos()[2]
+				call search('\\begin{', 'b')
 				call Tex_SetPos(pos)
-				return env
+				return getline(env_line)[ia-1:ib-2]
 			else
-				" this \\begin closes a \\end, continue searching.
-				let i = i - 1
-				continue
+				let ix = ix - 1
+				call search('\\begin{', 'b')
 			endif
+		else
+			let ix = ix + 1
+			call search('\\end{', 'b')
 		endif
 	endwhile
 endfunction

--- a/ftplugin/latex-suite/envmacros.vim
+++ b/ftplugin/latex-suite/envmacros.vim
@@ -921,11 +921,9 @@ function! Tex_GetCurrentEnv()
 				return getline(env_line)[ix-1:iy-1]
 			else
 				let n = n - 1
-				call search('\%(\\\@<!\%(\\\\\)*%.*\)\@<!\\begin{', 'b')
 			endif
 		else
 			let n = n + 1
-			call search('\%(\\\@<!\%(\\\\\)*%.*\)\@<!\\end{', 'b')
 		endif
 	endwhile
 endfunction


### PR DESCRIPTION
Let's say we have some code like
```latex
\begin{itemize}
  \item
    This is a matrix: $\begin{psmallmatrix} a & b \\ c & d \end{psmallmatrix}$. [here is cursor]
\end{itemize}
```
If I call `Tex_GetCurrentEnv()`, it will return the environment `psmallmatrix` even though I am in `itemize`. This PR will fix this problem. (And maybe the same thing would happen if it is not a singleline environment -- I have not tried it.)

I also want to point out that using the option `Tex_InsertItemOnNextLine` while inside the `psmallmatrix` environment will obtain `itemize` since it first creates a new line before calling `Tex_InsertItem`. Maybe this should be a separate issue, but since this PR will change the bugs behavior, I want to point it out.