### PR TITLE
Enable default frame folding

### DIFF
--- a/ftplugin/latex-suite/folding.vim
+++ b/ftplugin/latex-suite/folding.vim
@@ -121,7 +121,7 @@ function! MakeTexFolds(force, manual)
 		let g:Tex_FoldedCommands = g:Tex_FoldedCommands . s
 	endif
 
-	let s = 'verbatim,comment,eq,gather,align,figure,table,thebibliography,'
+	let s = 'verbatim,comment,eq,gather,align,figure,frame,table,thebibliography,'
 			\. 'keywords,abstract,titlepage'
 	if !exists('g:Tex_FoldedEnvironments')
 		let g:Tex_FoldedEnvironments = s


### PR DESCRIPTION
Hi everyone,
I noticed that folding is not enabled for the environment `frame`. Maybe the variable `s`  in line 124 of file ```~/vimlatex/ftplugin/latex-suite/folding.vim``` is badly initialized.

 I hope this could help in solving the issue.

Thanks,
Fabio. 