### PR TITLE
Add nestable environments

### DIFF
--- a/ftplugin/latex-suite/folding.vim
+++ b/ftplugin/latex-suite/folding.vim
@@ -297,7 +297,7 @@ function! MakeTexFolds(force, manual)
 					" In other words, the pattern is safe, but not exact.
 					call AddSyntaxFoldItem('^\s*\\'.s.'{[^{}]*$','^[^}]*}',0,0)
 				else
-					if s =~ 'itemize\|enumerate\|description'
+					if s =~ 'itemize\|enumerate\|description\|align\|gather'
 						" These environments can nest.
 						call AddSyntaxFoldItem('^\s*\\begin{'.s,'\(^\|\s\)\s*\\end{'.s,0,0,'^\s*\\begin{'.s,'\(^\|\s\)\s*\\end{'.s)
 					else


### PR DESCRIPTION
If you have something like
\begin{align}
maths
\begin{aligned}
more maths
\end{aligned}
yet more maths
\end{align}

the folding will be wrong as there is nested align* environments. Same thing for gathered.