### PR TITLE
Add folding for beamer frames

### DIFF
--- a/ftplugin/latex-suite/folding.vim
+++ b/ftplugin/latex-suite/folding.vim
@@ -257,6 +257,15 @@ function! MakeTexFolds(force, manual)
 	endif
 	" }}}
 
+	" {{{ frame (in beamer)
+	call AddSyntaxFoldItem (
+				\ '^\s*\\frame',
+				\ '^\s*\\frame\|^\s*\\end{document}',
+				\ 0,
+				\ -1,
+				\ )
+	" }}}
+
 	" {{{ title
 	if g:Tex_FoldedMisc =~ '\<title\>'
 		call AddSyntaxFoldItem (


### PR DESCRIPTION
In beamer, you can use the syntax \frame{...} to add a frame. I add folding functionality for this syntax.