### PR TITLE
Docstring fix

### DIFF
--- a/ftplugin/latex-suite/bibtools.py
+++ b/ftplugin/latex-suite/bibtools.py
@@ -31,7 +31,7 @@ else:
 
 class Bibliography(dict):
     def __init__(self, txt, macros={}):
-        """
+        r"""
         txt:
             a string which represents the entire bibtex entry. A typical
             entry is of the form:


### PR DESCRIPTION
The docstring for `Bibliography.__init__` had unescaped backslashes, making my vim installation complain about invalid escape sequences each time I open a `.tex` file. Now it's converted to a raw docstring per PEP 257.