### PR TITLE
Fix syntax warning for  python 3.12 and newer

### DIFF
--- a/ftplugin/latex-suite/bibtools.py
+++ b/ftplugin/latex-suite/bibtools.py
@@ -44,7 +44,6 @@ class Bibliography(dict):
                   pages = {41-78},
                   number = {1122},
                   owner = {Srinath},
-                  pdf = {C:\srinath\research\papers\Ellington-3-Kinematics.pdf},
                   timestamp = {2006.01.02},
                 }
         """


### PR DESCRIPTION
As the backslash in the file path is interpreted as an invalid escape sequence, one could mark the docstring as raw string or rather just remove the line altogehter, what was done here.

This resolves issue #225.